### PR TITLE
Fix/display pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ We use predefined latitude and longitude coordinates from various cities to fetc
 
 The app is functional, but there are still some improvements and bug fixes to be made. Here's what's on our radar:
 
-- [ ] 🔑 Add your API key to the `local.properties` file:
+- [ x ] 🔑 Add your API key to the `local.properties` file:
 `WEATHER_API_KEY= <your-api-key-here>`
-- [ ] 📊 Fetch and display **pressure** data from the API
+- [ x ] 📊 Fetch and display **pressure** data from the API
 - [ ] 🔄 Implement data refresh on **Refresh** button click
 - [ ] 🎨 Fix broken **weather icons**
 - [ ] 🧹 Eliminate **duplicate data** issues

--- a/app/src/main/java/com/example/findinglogs/view/recyclerview/adapter/WeatherListAdapter.java
+++ b/app/src/main/java/com/example/findinglogs/view/recyclerview/adapter/WeatherListAdapter.java
@@ -96,7 +96,7 @@ public class WeatherListAdapter extends RecyclerView.Adapter<WeatherListAdapter.
             String temp_min_value = "Temp. mín: " +
                     Utils.getCelsiusTemperatureFromKevin(weather.getMain().getTemp_min());
             temp_min.setText(temp_min_value);
-            String pressure_value = "Pressão: " + 1008.2 + "hPa";
+            String pressure_value = "Pressão: " + weather.getMain().getPressure() + "hPa";
             pressure.setText(pressure_value);
             String humidity_value = "Umidade: " + weather.getMain().getHumidity() + "%";
             humidity.setText(humidity_value);


### PR DESCRIPTION
Added the API key to `local.properties`
- Adjusted the code to correctly display the pressure using `weather.getMain().getPressure()`
- Now the atmospheric pressure value appears correctly in the interface

This change resolves part of the challenge checklist (`display pressure data`)